### PR TITLE
fix i18n

### DIFF
--- a/client/views/Home.vue
+++ b/client/views/Home.vue
@@ -50,8 +50,7 @@
             </a>
             <p class="text-muted-foreground text-sm">
               {{ t("home.download.mac.free") }}<br />
-              {{ t("home.download.mac.requirement", { apiKey: "" }) }}
-              <span class="font-semibold">{{ t("home.download.mac.apiKey") }}</span> が必要です。
+              {{ t("home.download.mac.requirement", { apiKey: t("home.download.mac.apiKey") }) }}
             </p>
           </CardContent>
           <CardFooter>
@@ -93,8 +92,7 @@
             </a>
             <p class="text-muted-foreground text-sm">
               {{ t("home.download.windows.free") }}<br />
-              {{ t("home.download.windows.requirement", { apiKey: "" }) }}
-              <span class="font-semibold">{{ t("home.download.windows.apiKey") }}</span> が必要です。
+              {{ t("home.download.windows.requirement", { apiKey: t("home.download.windows.apiKey") }) }}
             </p>
           </CardContent>
           <CardFooter>


### PR DESCRIPTION
i18n の補間を修正しました

<img width="2964" height="1874" alt="CleanShot 2025-10-21 at 15 19 49@2x" src="https://github.com/user-attachments/assets/dc6f1f59-d2fb-4d18-b69f-d1f04ee68ab1" />

en - win 
<img width="1196" height="233" alt="image" src="https://github.com/user-attachments/assets/b828df45-44b7-4429-a53b-c5b8a4fddeea" />

en -Mac
<img width="1128" height="226" alt="image" src="https://github.com/user-attachments/assets/a70a2287-0e81-44af-a228-90e37f5d0aab" />
