### PR TITLE
Use template literals for JSON examples in FAQ

### DIFF
--- a/client/i18n/en.ts
+++ b/client/i18n/en.ts
@@ -147,8 +147,7 @@ const lang = {
         steps: ["Switch to Advanced Mode", "Open the JSON tab", 'Add "duration: seconds" to the corresponding beat'],
         exampleLabel: "Example:",
         noteLabel: "Note:",
-        example:
-          '{\'{\'}\\n  "speaker": "Presenter",\\n  "text": "",\\n  "image": {\'{\'}\\n    "type": "textSlide",\\n    "slide": {\'{\'}\\n      "title": "no audio slide + duration",\\n      "bullets": [\\n        "duration 5"\\n      ]\\n    {\'}\'}\\n  {\'}\'},\\n  "duration": 5\\n{\'}\'}',
+        example: `{'{'}\n  "speaker": "Presenter",\n  "text": "",\n  "image": {'{'}\n    "type": "textSlide",\n    "slide": {'{'}\n      "title": "no audio slide + duration",\n      "bullets": [\n        "duration 5"\n      ]\n    {'}'}\n  {'}'},\n  "duration": 5\n{'}'}`,
         exampleNote: "In this example, the slide without narration will be displayed for 5 seconds.",
         note: "When adding duration, remember to add a comma (,) at the end of the previous item (the image object in this example).",
       },
@@ -163,8 +162,7 @@ const lang = {
         ],
         exampleLabel: "Example:",
         noteLabel: "Note:",
-        example:
-          '{\'{\'}\\n  "speaker": "Presenter",\\n  "text": "This beat has audio. add padding 6.",\\n  "audioParams": {\'{\'}\\n    "padding": 6\\n  {\'}\'},\\n  "moviePrompt": "Four shots in rapid succession: art, anime, documentary, and promotional style.",\\n  "enableLipSync": false\\n{\'}\'}',
+        example: `{'{'}\n  "speaker": "Presenter",\n  "text": "This beat has audio. add padding 6.",\n  "audioParams": {'{'}\n    "padding": 6\n  {'}'},\n  "moviePrompt": "Four shots in rapid succession: art, anime, documentary, and promotional style.",\n  "enableLipSync": false\n{'}'}`,
         exampleNote: "In this example, 6 seconds of padding is added to the end of the audio.",
         note: "When adding audioParams, remember to add a comma (,) at the end of the previous item.",
       },

--- a/client/i18n/ja.ts
+++ b/client/i18n/ja.ts
@@ -141,8 +141,7 @@ const lang = {
         steps: ["上級モードにする", "JSONタブを開く", "該当するビートに「duration: 秒数」を追加する"],
         exampleLabel: "例:",
         noteLabel: "注意:",
-        example:
-          '{\'{\'}\\n  "speaker": "Presenter",\\n  "text": "",\\n  "image": {\'{\'}\\n    "type": "textSlide",\\n    "slide": {\'{\'}\\n      "title": "no audio slide + duration",\\n      "bullets": [\\n        "duration 5"\\n      ]\\n    {\'}\'}\\n  {\'}\'},\\n  "duration": 5\\n{\'}\'}',
+        example: `{'{'}\n  "speaker": "Presenter",\n  "text": "",\n  "image": {'{'}\n    "type": "textSlide",\n    "slide": {'{'}\n      "title": "no audio slide + duration",\n      "bullets": [\n        "duration 5"\n      ]\n    {'}'}\n  {'}'},\n  "duration": 5\n{'}'}`,
         exampleNote: "この例では、セリフのないスライドが5秒間表示されます。",
         note: "duration を追加する場合は、その前の項目（この例では image オブジェクト）の最後にカンマ（,）を付けることを忘れないでください。",
       },
@@ -153,8 +152,7 @@ const lang = {
         steps: ["上級モードにする", "JSONタブを開く", "該当するビートに「audioParams.padding: 秒数」を追加する"],
         exampleLabel: "例:",
         noteLabel: "注意:",
-        example:
-          '{\'{\'}\\n  "speaker": "Presenter",\\n  "text": "This beat has audio. add padding 6.",\\n  "audioParams": {\'{\'}\\n    "padding": 6\\n  {\'}\'},\\n  "moviePrompt": "Four shots in rapid succession: art, anime, documentary, and promotional style.",\\n  "enableLipSync": false\\n{\'}\'}',
+        example: `{'{'}\n  "speaker": "Presenter",\n  "text": "This beat has audio. add padding 6.",\n  "audioParams": {'{'}\n    "padding": 6\n  {'}'},\n  "moviePrompt": "Four shots in rapid succession: art, anime, documentary, and promotional style.",\n  "enableLipSync": false\n{'}'}`,
         exampleNote: "この例では、音声の終端に6秒の余白を追加しています。",
         note: "audioParams を追加する場合は、その前の項目の最後にカンマ（,）を付けることを忘れないでください。",
       },


### PR DESCRIPTION
以下のように2箇所 x 2言語 = 4箇所変更しました。
mdファイルが1行で展開されている部分を改行が入るようにしました

<img width="1423" height="871" alt="CleanShot 2025-11-12 at 02 03 04" src="https://github.com/user-attachments/assets/1d8ec2b4-2200-4ad6-ab07-5e37dc91fd80" />
