### PR TITLE
feat: Update festival page to show 2025 results

### DIFF
--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -15,50 +15,53 @@ const lang = {
     title: "AI Short Film Festival 2025",
   },
   festival: {
-    subtitle: "MulmoCast AI Short Film Festival",
-    about: {
-      title: "About the Festival",
+    resultsAnnouncement: "Results Announcement",
+    grandPrix: {
+      title: "Grand Prix",
+      work: "The Nameless",
+      creator: "Hisho Kakihara",
       description:
-        "MulmoCast AI Short Film Festival is an event that accepts and showcases video works created using AI. Why not challenge yourself to create new forms of visual expression with your creativity and the power of MulmoCast?",
+        "A visual work depicting one night of a nameless young man who only photographs shadows, overlaying the sense of distance between AI and 'things we are somehow drawn to.' Unanimously selected as Grand Prix by the judges.",
     },
-    applicationMethod: {
-      title: "How to Apply",
-      step1: "Upload your work to YouTube (unlisted is allowed)",
-      step2: "Submit the following information via the application form (Google Form)",
-      requirements: {
-        title: "Work title",
-        youtubeLink: "YouTube link",
-        creator: "Creator name (individual/team name)",
-        contact: "Contact information",
-        script: "MulmoScript file (.json format)",
+    categoryAwards: {
+      title: "Category Awards",
+      visual: {
+        title: "Visual Award",
+        work: "The Nameless",
+        creator: "Hisho Kakihara",
+      },
+      animation: {
+        title: "Animation Award",
+        work: "Beyond One Click",
+        creator: "Kawabe Shinkun",
+      },
+      promotion: {
+        title: "Promotion Award",
+        work: "W Pepper Melon",
+        creator: "ungr18",
+      },
+      documentary: {
+        title: "Documentary Award",
+        work: "AUTHENTIC ZERO",
+        creator: "keythpiece",
       },
     },
-    eligibility: {
-      title: "Eligibility Requirements",
-      items: [
-        "Applicants must be 18 years or older (minors are generally not eligible, except with individual permission from the organizer)",
-        "Work must be created using MulmoCast",
-        "Multiple submissions not allowed",
-        "Team submissions allowed",
-        "Concurrent applications to other contests not allowed",
-        "Overseas applications accepted (prize money subject to separate arrangements)",
-      ],
+    statistics: {
+      title: "Event Overview",
+      totalEntries: "Total Entries: 184 works",
+      eventDate: "Review Live Date: December 13, 2025",
+      totalPrize: "Total Prize Money: 900,000 JPY (Grand Prix: 500,000 JPY)",
     },
-    results: {
-      title: "Results Announcement",
-      items: [
-        "Scheduled to be announced on YouTube Live in {date}",
-        "Planned to be broadcast on TECH WORLD channel + other channels",
-        "Participation limited to online",
-      ],
-      date: "mid-December",
-    },
-    latestInfo: {
-      title: "Latest Information",
+    reviewLive: {
+      title: "Review Live",
       description:
-        "Details and application form are now available {eventLink}. For the latest information, please check our X account {twitterLink}.",
-      eventLinkText: "here",
-      twitterHandle: "{'@'}mulmocast",
+        "The review live was held on YouTube on December 13, 2025, with judges including Satoshi Nakajima (Chief Judge), Yohei Sadoshima, Akihiko Shirai, and Yuka Osumi.",
+    },
+    relatedLinks: {
+      title: "Related Links",
+      noteArticle: "Complete Review Live Summary (note article)",
+      passedWorks: "First Round Passed Works",
+      officialPage: "Official Event Page",
     },
     backButton: "Back to Home",
   },

--- a/web/src/i18n/ja.ts
+++ b/web/src/i18n/ja.ts
@@ -15,45 +15,53 @@ const lang = {
     title: "AIショートフィルムフェス 2025",
   },
   festival: {
-    subtitle: "MulmoCast AI Short Film Festival",
-    about: {
-      title: "映画祭について",
+    resultsAnnouncement: "結果発表",
+    grandPrix: {
+      title: "グランプリ",
+      work: "無名の人",
+      creator: "柿原飛翔",
       description:
-        "MulmoCast AI Short Film Festivalは、AIを活用して制作された動画作品を募集・展示するイベントです。あなたの創造性とMulmoCastの力で、新しい映像表現に挑戦しませんか？",
+        "影ばかり撮る無名の青年の一夜を通じて、「なんとなく惹かれてしまうもの」とAIとの距離感を重ねて描いた映像作品。審査員満場一致でグランプリに選出。",
     },
-    applicationMethod: {
-      title: "応募方法",
-      step1: "作品をYouTubeにアップロード（限定公開可）",
-      step2: "応募フォーム（Googleフォーム）から以下の情報を申請",
-      requirements: {
-        title: "作品タイトル",
-        youtubeLink: "YouTubeリンク",
-        creator: "制作者名（個人／チーム名）",
-        contact: "連絡先",
-        script: "MulmoScript ファイル (.json 形式)",
+    categoryAwards: {
+      title: "部門賞",
+      visual: {
+        title: "ビジュアル部門",
+        work: "無名の人",
+        creator: "柿原飛翔",
+      },
+      animation: {
+        title: "アニメーション部門",
+        work: "1クリックの向こう側",
+        creator: "カワベシンクン",
+      },
+      promotion: {
+        title: "プロモーション部門",
+        work: "W Pepper Melon",
+        creator: "ungr18",
+      },
+      documentary: {
+        title: "ドキュメンタリー部門",
+        work: "AUTHENTIC ZERO",
+        creator: "keythpiece",
       },
     },
-    eligibility: {
-      title: "応募要件",
-      items: [
-        "18歳以上（未成年は原則応募不可。但し主催者が個別に許可した場合を除く。）",
-        "MulmoCastで制作した作品であること",
-        "複数応募不可",
-        "チーム応募可",
-        "他のコンテストとの併願不可",
-        "海外応募可（賞金対応は別途調整）",
-      ],
+    statistics: {
+      title: "開催概要",
+      totalEntries: "総応募数: 184作品",
+      eventDate: "審査ライブ開催日: 2025年12月13日",
+      totalPrize: "賞金総額: 90万円（グランプリ 50万円）",
     },
-    results: {
-      title: "結果発表",
-      items: ["{date} YouTubeライブで発表予定", "TECH WORLDチャンネル＋各社配信予定", "参加はオンラインに限定"],
-      date: "12月中旬",
+    reviewLive: {
+      title: "審査ライブ",
+      description:
+        "2025年12月13日にYouTubeで開催された審査ライブでは、審査員長の中島聡氏をはじめ、佐渡島庸平氏、白井暁彦氏、オースミユーカ氏による審査が行われました。",
     },
-    latestInfo: {
-      title: "最新情報",
-      description: "詳細・応募フォームは{eventLink}で公開中です。最新情報はXアカウント{twitterLink}をご確認ください。",
-      eventLinkText: "こちら",
-      twitterHandle: "{'@'}mulmocast",
+    relatedLinks: {
+      title: "関連リンク",
+      noteArticle: "審査ライブ全まとめ（note記事）",
+      passedWorks: "一次予選通過作品一覧",
+      officialPage: "公式イベントページ",
     },
     backButton: "ホームに戻る",
   },

--- a/web/src/views/Festival.vue
+++ b/web/src/views/Festival.vue
@@ -2,111 +2,190 @@
   <div class="min-h-screen">
     <Navigation />
     <div class="flex items-center justify-center p-4">
-      <div class="w-full max-w-2xl space-y-6 py-8">
+      <div class="w-full max-w-3xl space-y-6 py-8">
         <!-- Header -->
         <div class="text-center">
           <h1 class="text-foreground text-3xl font-extrabold sm:text-3xl md:text-4xl">{{ t("filmFes.title") }}</h1>
-          <p class="text-muted-foreground mt-4 text-lg">{{ t("festival.subtitle") }}</p>
+          <p class="text-muted-foreground mt-4 text-lg">{{ t("festival.resultsAnnouncement") }}</p>
         </div>
 
-        <!-- Introduction -->
-        <Card class="hover:bg-muted/50">
+        <!-- Grand Prix -->
+        <Card class="border-2 border-yellow-500">
           <CardHeader>
-            <CardTitle>{{ t("festival.about.title") }}</CardTitle>
+            <CardTitle class="flex items-center gap-2 text-yellow-500">
+              <span class="text-2xl">&#127942;</span>
+              {{ t("festival.grandPrix.title") }}
+            </CardTitle>
           </CardHeader>
           <CardContent>
-            <p class="text-muted-foreground">
-              {{ t("festival.about.description") }}
-            </p>
+            <div class="space-y-4">
+              <div>
+                <h3 class="text-foreground text-xl font-bold">{{ t("festival.grandPrix.work") }}</h3>
+                <p class="text-muted-foreground">{{ t("festival.grandPrix.creator") }}</p>
+              </div>
+              <p class="text-muted-foreground text-sm">{{ t("festival.grandPrix.description") }}</p>
+              <div class="aspect-video w-full">
+                <iframe
+                  class="h-full w-full rounded-lg"
+                  src="https://www.youtube.com/embed/SlHhzFUOXBQ"
+                  :title="t('festival.grandPrix.work')"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen
+                ></iframe>
+              </div>
+            </div>
           </CardContent>
         </Card>
 
-        <!-- Application Method -->
+        <!-- Category Awards -->
         <Card class="hover:bg-muted/50">
           <CardHeader>
-            <CardTitle>{{ t("festival.applicationMethod.title") }}</CardTitle>
+            <CardTitle>{{ t("festival.categoryAwards.title") }}</CardTitle>
           </CardHeader>
           <CardContent>
-            <ol class="text-muted-foreground list-decimal space-y-2 pl-5">
-              <li>{{ t("festival.applicationMethod.step1") }}</li>
-              <li>
-                {{ t("festival.applicationMethod.step2") }}
-                <ul class="mt-2 list-disc space-y-1 pl-5">
-                  <li>{{ t("festival.applicationMethod.requirements.title") }}</li>
-                  <li>{{ t("festival.applicationMethod.requirements.youtubeLink") }}</li>
-                  <li>{{ t("festival.applicationMethod.requirements.creator") }}</li>
-                  <li>{{ t("festival.applicationMethod.requirements.contact") }}</li>
-                  <li>{{ t("festival.applicationMethod.requirements.script") }}</li>
-                </ul>
-              </li>
-            </ol>
-          </CardContent>
-        </Card>
-
-        <!-- Application Requirements -->
-        <Card class="hover:bg-muted/50">
-          <CardHeader>
-            <CardTitle>{{ t("festival.eligibility.title") }}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul class="text-muted-foreground list-disc space-y-2 pl-5">
-              <li>{{ t("festival.eligibility.items.0") }}</li>
-              <li>{{ t("festival.eligibility.items.1") }}</li>
-              <li>{{ t("festival.eligibility.items.2") }}</li>
-              <li>{{ t("festival.eligibility.items.3") }}</li>
-              <li>{{ t("festival.eligibility.items.4") }}</li>
-              <li>{{ t("festival.eligibility.items.5") }}</li>
-            </ul>
-          </CardContent>
-        </Card>
-
-        <!-- Results Announcement -->
-        <Card class="hover:bg-muted/50">
-          <CardHeader>
-            <CardTitle>{{ t("festival.results.title") }}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul class="text-muted-foreground list-disc space-y-2 pl-5">
-              <li>
-                <span class="font-semibold">{{ t("festival.results.date") }}</span>
-                {{ t("festival.results.items.0", { date: "" }) }}
-              </li>
-              <li>{{ t("festival.results.items.1") }}</li>
-              <li>{{ t("festival.results.items.2") }}</li>
-            </ul>
-          </CardContent>
-        </Card>
-
-        <!-- Latest Information -->
-        <Card class="hover:bg-muted/50">
-          <CardHeader>
-            <CardTitle>{{ t("festival.latestInfo.title") }}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p class="text-muted-foreground">
-              <i18n-t keypath="festival.latestInfo.description" tag="span">
-                <template #eventLink>
+            <div class="space-y-6">
+              <!-- Visual Award -->
+              <div class="space-y-2">
+                <h3 class="text-foreground font-semibold">{{ t("festival.categoryAwards.visual.title") }}</h3>
+                <p class="text-muted-foreground">
                   <a
-                    href="https://www.mag2.com/events/ai-film-fes2025/"
+                    href="https://www.youtube.com/watch?v=SlHhzFUOXBQ"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-primary hover:underline"
                   >
-                    {{ t("festival.latestInfo.eventLinkText") }}
+                    {{ t("festival.categoryAwards.visual.work") }}
                   </a>
-                </template>
-                <template #twitterLink>
+                  - {{ t("festival.categoryAwards.visual.creator") }}
+                </p>
+              </div>
+
+              <!-- Animation Award -->
+              <div class="space-y-2">
+                <h3 class="text-foreground font-semibold">{{ t("festival.categoryAwards.animation.title") }}</h3>
+                <p class="text-muted-foreground">
                   <a
-                    href="https://x.com/mulmocast"
+                    href="https://www.youtube.com/watch?v=ftdpy6NHfLA"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="text-primary hover:underline"
                   >
-                    {{ t("festival.latestInfo.twitterHandle") }}
+                    {{ t("festival.categoryAwards.animation.work") }}
                   </a>
-                </template>
-              </i18n-t>
-            </p>
+                  - {{ t("festival.categoryAwards.animation.creator") }}
+                </p>
+              </div>
+
+              <!-- Promotion Award -->
+              <div class="space-y-2">
+                <h3 class="text-foreground font-semibold">{{ t("festival.categoryAwards.promotion.title") }}</h3>
+                <p class="text-muted-foreground">
+                  <a
+                    href="https://www.youtube.com/watch?v=9qaJCGRm5Dc"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary hover:underline"
+                  >
+                    {{ t("festival.categoryAwards.promotion.work") }}
+                  </a>
+                  - {{ t("festival.categoryAwards.promotion.creator") }}
+                </p>
+              </div>
+
+              <!-- Documentary Award -->
+              <div class="space-y-2">
+                <h3 class="text-foreground font-semibold">{{ t("festival.categoryAwards.documentary.title") }}</h3>
+                <p class="text-muted-foreground">
+                  <a
+                    href="https://www.youtube.com/watch?v=D5LvtyH2VU4"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary hover:underline"
+                  >
+                    {{ t("festival.categoryAwards.documentary.work") }}
+                  </a>
+                  - {{ t("festival.categoryAwards.documentary.creator") }}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <!-- Statistics -->
+        <Card class="hover:bg-muted/50">
+          <CardHeader>
+            <CardTitle>{{ t("festival.statistics.title") }}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul class="text-muted-foreground list-disc space-y-2 pl-5">
+              <li>{{ t("festival.statistics.totalEntries") }}</li>
+              <li>{{ t("festival.statistics.eventDate") }}</li>
+              <li>{{ t("festival.statistics.totalPrize") }}</li>
+            </ul>
+          </CardContent>
+        </Card>
+
+        <!-- Review Live -->
+        <Card class="hover:bg-muted/50">
+          <CardHeader>
+            <CardTitle>{{ t("festival.reviewLive.title") }}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div class="space-y-4">
+              <p class="text-muted-foreground">{{ t("festival.reviewLive.description") }}</p>
+              <div class="aspect-video w-full">
+                <iframe
+                  class="h-full w-full rounded-lg"
+                  src="https://www.youtube.com/embed/Ow69HedV2e0"
+                  :title="t('festival.reviewLive.title')"
+                  frameborder="0"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowfullscreen
+                ></iframe>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <!-- Related Links -->
+        <Card class="hover:bg-muted/50">
+          <CardHeader>
+            <CardTitle>{{ t("festival.relatedLinks.title") }}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul class="text-muted-foreground list-disc space-y-2 pl-5">
+              <li>
+                <a
+                  href="https://note.com/aicu/n/n434b9823d39b"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary hover:underline"
+                >
+                  {{ t("festival.relatedLinks.noteArticle") }}
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.mag2.com/events/ai-film-fes2025/pass.html"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary hover:underline"
+                >
+                  {{ t("festival.relatedLinks.passedWorks") }}
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.mag2.com/events/ai-film-fes2025/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary hover:underline"
+                >
+                  {{ t("festival.relatedLinks.officialPage") }}
+                </a>
+              </li>
+            </ul>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary
- Add Grand Prix winner display: "The Nameless" (無名の人) by Hisho Kakihara
- Add all category award winners (Visual, Animation, Promotion, Documentary)
- Add event statistics (184 entries, December 13, 2025, 900,000 JPY prize)
- Add review live video embed from YouTube
- Add related links section (note article, passed works, official page)
- Update i18n files for both Japanese and English

## Test plan
- [ ] Check festival page displays correctly in Japanese
- [ ] Check festival page displays correctly in English
- [ ] Verify YouTube video embeds load properly
- [ ] Verify all external links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restructured festival information with prominent Grand Prix award showcase and embedded video content.
  * Introduced Category Awards section displaying multiple award categories (visual, animation, promotion, documentary).
  * Added Statistics section featuring total entries, event date, and prize information.
  * New Review Live section with embedded video content.
  * Added Related Links section with note article, passed works, and official page links.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->