### PR TITLE
docs: make card titles linkable on docs index page

### DIFF
--- a/web/src/views/docs/DocsEasy.vue
+++ b/web/src/views/docs/DocsEasy.vue
@@ -27,7 +27,7 @@
       </section>
 
       <!-- Installation -->
-      <section class="mb-12">
+      <section id="install" class="mb-12">
         <h2 class="text-foreground mb-4 text-2xl font-bold">
           {{ t("docs.easy.install") }}
         </h2>
@@ -37,7 +37,7 @@
       </section>
 
       <!-- Quick Start -->
-      <section class="mb-12">
+      <section id="quickstart" class="mb-12">
         <h2 class="text-foreground mb-4 text-2xl font-bold">
           {{ t("docs.easy.quickstart") }}
         </h2>
@@ -118,7 +118,7 @@
       </section>
 
       <!-- Available Commands -->
-      <section class="mb-12">
+      <section id="commands" class="mb-12">
         <h2 class="text-foreground mb-4 text-2xl font-bold">
           {{ t("docs.easy.commands") }}
         </h2>

--- a/web/src/views/docs/DocsIndex.vue
+++ b/web/src/views/docs/DocsIndex.vue
@@ -25,10 +25,26 @@
             </div>
           </CardHeader>
           <CardContent>
-            <ul class="text-muted-foreground space-y-2 text-sm">
-              <li>{{ t("docs.cli.item1") }}</li>
-              <li>{{ t("docs.cli.item2") }}</li>
-              <li>{{ t("docs.cli.item3") }}</li>
+            <ul class="space-y-2 text-sm">
+              <li>
+                <a
+                  :href="localizedUrl('/docs/cli/quickstart')"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.cli.item1") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/cli/mulmoscript')"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.cli.item2") }}</a
+                >
+              </li>
+              <li>
+                <a :href="localizedUrl('/docs/cli')" class="text-muted-foreground hover:text-primary hover:underline">{{
+                  t("docs.cli.item3")
+                }}</a>
+              </li>
             </ul>
           </CardContent>
           <CardFooter>
@@ -52,10 +68,28 @@
             </div>
           </CardHeader>
           <CardContent>
-            <ul class="text-muted-foreground space-y-2 text-sm">
-              <li>{{ t("docs.app.item1") }}</li>
-              <li>{{ t("docs.app.item2") }}</li>
-              <li>{{ t("docs.app.item3") }}</li>
+            <ul class="space-y-2 text-sm">
+              <li>
+                <a
+                  :href="localizedUrl('/docs/app') + '#download'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.app.item1") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/app') + '#usage'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.app.item2") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/app') + '#settings'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.app.item3") }}</a
+                >
+              </li>
             </ul>
           </CardContent>
           <CardFooter>
@@ -79,10 +113,28 @@
             </div>
           </CardHeader>
           <CardContent>
-            <ul class="text-muted-foreground space-y-2 text-sm">
-              <li>{{ t("docs.easy.item1") }}</li>
-              <li>{{ t("docs.easy.item2") }}</li>
-              <li>{{ t("docs.easy.item3") }}</li>
+            <ul class="space-y-2 text-sm">
+              <li>
+                <a
+                  :href="localizedUrl('/docs/easy') + '#install'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.easy.item1") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/easy') + '#commands'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.easy.item2") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/easy') + '#quickstart'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.easy.item3") }}</a
+                >
+              </li>
             </ul>
           </CardContent>
           <CardFooter>
@@ -106,10 +158,28 @@
             </div>
           </CardHeader>
           <CardContent>
-            <ul class="text-muted-foreground space-y-2 text-sm">
-              <li>{{ t("docs.preprocessor.item1") }}</li>
-              <li>{{ t("docs.preprocessor.item2") }}</li>
-              <li>{{ t("docs.preprocessor.item3") }}</li>
+            <ul class="space-y-2 text-sm">
+              <li>
+                <a
+                  :href="localizedUrl('/docs/preprocessor') + '#profiles'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.preprocessor.item1") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/preprocessor') + '#ai-summarize'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.preprocessor.item2") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/preprocessor') + '#ai-qa'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.preprocessor.item3") }}</a
+                >
+              </li>
             </ul>
           </CardContent>
           <CardFooter>
@@ -133,10 +203,28 @@
             </div>
           </CardHeader>
           <CardContent>
-            <ul class="text-muted-foreground space-y-2 text-sm">
-              <li>{{ t("docs.mulmochat.item1") }}</li>
-              <li>{{ t("docs.mulmochat.item2") }}</li>
-              <li>{{ t("docs.mulmochat.item3") }}</li>
+            <ul class="space-y-2 text-sm">
+              <li>
+                <a
+                  :href="localizedUrl('/docs/mulmochat') + '#overview'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.mulmochat.item1") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/mulmochat') + '#protocol'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.mulmochat.item2") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  :href="localizedUrl('/docs/mulmochat') + '#plugins'"
+                  class="text-muted-foreground hover:text-primary hover:underline"
+                  >{{ t("docs.mulmochat.item3") }}</a
+                >
+              </li>
             </ul>
           </CardContent>
           <CardFooter>

--- a/web/src/views/docs/DocsPreprocessor.vue
+++ b/web/src/views/docs/DocsPreprocessor.vue
@@ -172,7 +172,7 @@ mulmocast-preprocessor profiles script.json</code></pre>
         </h2>
 
         <!-- Summarize -->
-        <h3 class="text-foreground mb-2 font-semibold">
+        <h3 id="ai-summarize" class="text-foreground mb-2 font-semibold">
           {{ t("docs.preprocessor.aiSummarize") }}
         </h3>
         <p class="text-muted-foreground mb-3">
@@ -196,7 +196,7 @@ mulmocast-preprocessor summarize script.json --provider anthropic</code></pre>
         </div>
 
         <!-- Query -->
-        <h3 class="text-foreground mb-2 font-semibold">
+        <h3 id="ai-qa" class="text-foreground mb-2 font-semibold">
           {{ t("docs.preprocessor.aiQA") }}
         </h3>
         <p class="text-muted-foreground mb-3">


### PR DESCRIPTION
## Summary
- DocsIndex.vue の各カードのタイトル（CardTitle）をクリック可能なリンクに変更
- 5つのカード（CLI, App, Easy, Preprocessor, MulmoChat）すべてに適用
- ホバー時にアンダーライン表示

## Test plan
- [ ] `/docs` ページで各カードのタイトルをクリックして遷移確認
- [ ] ホバー時のアンダーライン表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded clickable areas in documentation sections to include both titles and descriptions, enabling navigation by clicking anywhere in the docs card rather than just the title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->